### PR TITLE
Replaced fs.mkdir() with fstools.mkdir() in private function copy_directory()

### DIFF
--- a/lib/fs-tools.js
+++ b/lib/fs-tools.js
@@ -129,7 +129,7 @@ function copy_symlink(src, dst, callback) {
 
 
 function copy_directory(src, dst, callback) {
-  fs.mkdir(dst, '0755', function (err) {
+  fstools.mkdir(dst, '0755', function (err) {
     if (err) {
       callback(err);
       return;


### PR DESCRIPTION
Using NDoc to create HTML documentation I get an error. When it tries to copy the skeleton dir to my target dir, it calls fs.mkdir(dst), which does not test for existence of dst. At least under Windows this throws an error and the copy exits before it's begun. Your method fstools.mkdir on the other hand checks for existence und hence protects from this error.
My computer is running Windows 7. I don't know if this problem actually exists in Linux / Mac but I think my solution should not break on any platform.
{
  [Error: EEXIST, file already exists '...\doc']
  errno: 47,
  code: 'EEXIST',
  path: '...\doc'
}
